### PR TITLE
Update Ruby to 2.2.3

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,10 @@ suites:
     run_list:
       - recipe[base::default]
     attributes:
+      authorization:
+        sudo:
+          users:
+            - vagrant
       base:
         packages:
           - silversearcher-ag

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ A cookbook for all machines. This should be put at the top of the run list for a
 * Sets up apt cookbook
 * Installs packages defined in `node["base"]["packages"]` (see attributes)
 * Installs [runit]
+* Installs a recent version of git from source
 * Configures chef-client to run periodically (see attributes)
 * Creates a sudoers group and grants passwordless sudo access to it
+* Installs a system ruby (see attributes)
 
 [runit]: http://smarden.org/runit/
 
@@ -21,6 +23,8 @@ Attribute|Description|Default
 `node["base"]["packages"]` | An array of apt packages to be installed | `[]`
 `node["base"]["git"]["version"]` | The version of git to install | `2.6.4`
 `node["base"]["git"]["checksum"]` | The sha256 checksum of the version's tarball | `08e3ccdba87ca55140c8155a07e147f6c1cdd7b574690e960763b18474fd05ed`
+`node["base"]["ruby"]["source"]` | The URL of the ruby tarball to install | `http://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz`
+`node["base"]["ruby"]["checksum"]` | The sha256 checksum of the tarball | `df795f2f99860745a416092a4004b016ccf77e8b82dec956b120f18bdc71edce`
 
 
 ### Chef-Client Attributes
@@ -41,7 +45,7 @@ See [sudo cookbook] for options.
 Attribute|Description|Default
 ---------|-----------|-------
 `node["authorization"]["sudo"]["groups"]` | Groups to enable sudo access for | `%w(sudoers)`
-`node["authorization"]["sudo"]["passwordless"]` | Whether or not to require passwords for sudo | `false`
+`node["authorization"]["sudo"]["passwordless"]` | Whether or not to require passwords for sudo | `true`
 
 [sudo cookbook]: https://github.com/chef-cookbooks/sudo
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A cookbook for all machines. This should be put at the top of the run list for a
 
 Attribute|Description|Default
 ---------|-----------|-------
-`node["base"]["packages"]` | An array of apt packages to be installed | `[]`
+`node["base"]["packages"]` | An array of apt packages to be installed | `curl`<br>`zlib1g-dev`<br>`libssl-dev`<br>`libreadline-dev`<br>`libyaml-dev`<br>`libcurl4-openssl-dev`<br>`libffi-dev`
 `node["base"]["git"]["version"]` | The version of git to install | `2.6.4`
 `node["base"]["git"]["checksum"]` | The sha256 checksum of the version's tarball | `08e3ccdba87ca55140c8155a07e147f6c1cdd7b574690e960763b18474fd05ed`
 `node["base"]["ruby"]["source"]` | The URL of the ruby tarball to install | `http://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,6 @@ default["base"]["packages"] = %w(
 )
 
 default["base"]["ruby"] = {
-  "source" => "http://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz",
+  "source"   => "http://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz",
   "checksum" => "df795f2f99860745a416092a4004b016ccf77e8b82dec956b120f18bdc71edce"
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,4 +3,17 @@ default["base"]["git"] = {
   "checksum" => "08e3ccdba87ca55140c8155a07e147f6c1cdd7b574690e960763b18474fd05ed"
 }
 
-default["base"]["packages"] = []
+default["base"]["packages"] = %w(
+  curl
+  zlib1g-dev
+  libssl-dev
+  libreadline-dev
+  libyaml-dev
+  libcurl4-openssl-dev
+  libffi-dev
+)
+
+default["base"]["ruby"] = {
+  "source" => "http://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz",
+  "checksum" => "df795f2f99860745a416092a4004b016ccf77e8b82dec956b120f18bdc71edce"
+}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,7 @@
 include_recipe "apt"
 include_recipe "build-essential"
 include_recipe "base::git"
+include_recipe "base::ruby"
 include_recipe "chef-client"
 include_recipe "runit"
 include_recipe "sudo"

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -1,0 +1,14 @@
+#
+# Cookbook Name:: base
+# Recipe:: ruby
+#
+# Copyright (c) 2015 The Authors, All Rights Reserved.
+
+ark "ruby" do
+  url node["base"]["ruby"]["source"]
+  checksum node["base"]["ruby"]["checksum"]
+  autoconf_opts %w(--disable-install-doc)
+  action :install_with_make
+end
+
+gem_package "bundler"

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -7,7 +7,7 @@
 require "spec_helper"
 
 describe "base::default" do
-  INCLUDED_RECIPES = %w(apt build-essential base::git chef-client runit sudo)
+  INCLUDED_RECIPES = %w(apt build-essential base::git base::ruby chef-client runit sudo)
 
   cached(:chef_run) do
     stub_command("which sudo")

--- a/spec/unit/recipes/ruby_spec.rb
+++ b/spec/unit/recipes/ruby_spec.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: dev
+# Spec:: ruby
+#
+# Copyright (c) 2015 The Authors, All Rights Reserved.
+
+require "spec_helper"
+
+describe "base::ruby" do
+  cached(:chef_run) do
+    runner = ChefSpec::ServerRunner.new
+    runner.converge(described_recipe)
+  end
+
+  it "makes and installs ruby from source" do
+    expect(chef_run).to install_with_make_ark("ruby").with(
+      url: "http://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz",
+      checksum: "df795f2f99860745a416092a4004b016ccf77e8b82dec956b120f18bdc71edce",
+      autoconf_opts: %w(--disable-install-doc)
+    )
+  end
+
+  it "installs bundler" do
+    expect(chef_run).to install_gem_package("bundler")
+  end
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "base::default" do
-  APPS     = %w(ag chef-client git runsv sv).freeze
+  APPS     = %w(ag chef-client git ruby runsv sv).freeze
   PACKAGES = %w(autoconf build-essential).freeze
 
   APPS.each do |app|
@@ -19,6 +19,12 @@ describe "base::default" do
   context "git" do
     describe command("git version") do
       its(:stdout) { should contain("git version 2.6.4") }
+    end
+  end
+
+  context "ruby" do
+    describe command("ruby -v") do
+      its(:stdout) { should contain("2.2.3") }
     end
   end
 end


### PR DESCRIPTION
# The Problem

The default ruby package for ubuntu uses Ruby 1.9.3...ew. Several applications I intend to run require Ruby >= 2.0
# The Solution

Building ruby 2.2.3 from source and installing `/usr/local`. I've also installed `bundler` as the one and only global gem and a few apt packages to support gems with native extensions.
